### PR TITLE
Add Behringer TD-3-MO

### DIFF
--- a/Behringer/TD-3-MO.csv
+++ b/Behringer/TD-3-MO.csv
@@ -1,0 +1,3 @@
+manufacturer,device,section,parameter_name,parameter_description,cc_msb,cc_lsb,cc_min_value,cc_max_value,nrpn_msb,nrpn_lsb,nrpn_min_value,nrpn_max_value,orientation,notes,usage
+Behringer,TD-3-MO,VCF,Cutoff,,74,,0,127,,,,,0-based,,
+Behringer,TD-3-MO,General,Accent,,120,,0,127,,,,,,,parameter change triggers accent


### PR DESCRIPTION
The TD-3-MO supports only two CC messages from what I can tell. The manual isn't of much help, so I found out the two channels by trial & error. Didn't check any NRPN channels.