### PR TITLE
add definition for Trinity

### DIFF
--- a/Modbap/Trinity.csv
+++ b/Modbap/Trinity.csv
@@ -1,0 +1,17 @@
+﻿manufacturer,device,section,parameter_name,parameter_description,cc_msb,cc_lsb,cc_min_value,cc_max_value,cc_default_value,nrpn_msb,nrpn_lsb,nrpn_min_value,nrpn_max_value,nrpn_default_value,orientation,notes,usage
+Modbap,Trinity,General,Sweep Knob,Envelope depth for pitch modulation,75,,0,127,,,,,,,0-based,Ratchet amount w/ Arcade,0~127: Sweep amount
+Modbap,Trinity,General,Time Knob,Rate of the pitch sweep,19,,0,127,,,,,,,0-based,Ratchet duration w/ Arcade,0~127: Time amount
+Modbap,Trinity,General,Ratchet Amount,Ratchet amount w/ Arcade,75,,0,127,,,,,,,0-based,,0~127: Sweep amount
+Modbap,Trinity,General,Ratchet Duration,Ratchet duration w/ Arcade,19,,0,127,,,,,,,0-based,,0~127: Time amount
+Modbap,Trinity,General,EQ Knob,DJ-style state-variable filter,74,,0,127,64,,,,,,centered,,0~63: Low-Pass;  64~127: High-Pass
+Modbap,Trinity,General,Volume Knob,Output level for the selected drum channel,7,,0,127,,,,,,,0-based,,0~127: Volume
+Modbap,Trinity,General,Character Knob,Primary timbre control,70,,0,127,,,,,,,0-based,,0~127: Character
+Modbap,Trinity,General,Clipper Knob,Wave-shaping distortion amount,77,,0,127,,,,,,,0-based,,0~127: Clipper amount
+Modbap,Trinity,General,Hold Knob,Hold time of the amp envelope,16,,0,127,,,,,,,0-based,,0~127: Hold amount
+Modbap,Trinity,General,Shape Knob,Secondary timbre control,79,,0,127,,,,,,,0-based,,0~127: Shape
+Modbap,Trinity,General,Grit Knob,Noise or tertiary timbre control,78,,0,127,,,,,,,0-based,,0~127: Grit amount
+Modbap,Trinity,General,Decay Knob,Envelope decay time,72,,0,127,,,,,,,0-based,,0~127: Decay amount
+Modbap,Trinity,General,Stack Spread Knob,Time spread for stacked voices,86,,0,127,,,,,,,0-based,,0~127: Stack Spread
+Modbap,Trinity,General,Cycle Button,Selects Cycle mode,17,,0,127,,,,,,,0-based,,0-42: Off; 43-84: Round Robin; 85-127: Random
+Modbap,Trinity,General,Type Button,Selects Algorithm type,18,,0,127,,,,,,,0-based,,0-31: Block; 32-62: Heap; 63-93: Neon; 94-127: Arcade
+Modbap,Trinity,General,Stack Button,Selects Stack mode,85,,0,127,,,,,,,0-based,,0-42: Off; 43-84: 2-Stack; 85-127: 3-Stack


### PR DESCRIPTION
This PR adds a definition for the [Modbap Trinity v1.0](https://www.modbap.com/products/trinity) eurorack module. The mapping is documented on page 21 of the manual ([PDF](https://cdn.shopify.com/s/files/1/0597/8665/7952/files/Trinity_Manual_1v0_12122022.pdf)).

Please note the two additional parameter names (tied to CC 19 and 75) to account for behavior that is notably different when using one specific algorithm (mode) on a channel.