### PR TITLE
Updating Tonverk definition to match OS 1.3.0 manual

### DIFF
--- a/Elektron/Tonverk.csv
+++ b/Elektron/Tonverk.csv
@@ -17,6 +17,48 @@ Elektron,Tonverk,Audio Track: Source,Source: Parameter E,,20,,0,127,,,,,,,0-base
 Elektron,Tonverk,Audio Track: Source,Source: Parameter F,,21,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Audio Track: Source,Source: Parameter G,,22,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Audio Track: Source,Source: Parameter H,,23,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Single Player,Single Player: Tune,,16,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Single Player,Single Player: Play Mode,,17,,0,3,,,,,,,0-based,,0: Reverse; 1: Reverse Loop; 2: Forward Loop; 3: Forward
+Elektron,Tonverk,Machine: Single Player,Single Player: Loop Crossfade,,18,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Single Player,Single Player: Sample Slot,,19,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Single Player,Single Player: Start,,20,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Single Player,Single Player: Loop Start,,21,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Single Player,Single Player: Loop End,,22,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Single Player,Single Player: End,,23,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Multi Player,Multi Player: Tune,,16,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Multi Player,Multi Player: Level,,20,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Multi Player,Multi Player: Vibrato Depth,,21,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Multi Player,Multi Player: Vibrato Speed,,22,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Multi Player,Multi Player: Vibrato Fade,,23,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Tune,,16,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Density,,17,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Size,,18,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Sample Slot,,19,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Position,,20,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Scan,,21,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Spread,,22,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Pan,,23,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Grain Amount,,24,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Direction,,25,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Window Fade,,26,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Window Shape,,27,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Grainer,Grainer: Play Mode,,30,,0,2,,,,,,,0-based,,0: Random; 1: Sync; 2: Osc
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Tune,,16,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Level,,17,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Position,,18,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Wavetable Slot,,19,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Speed,,20,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Animate Level,,21,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Animate Position,,22,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 1: Animate Shape,,23,,0,11,,,,,,,0-based,,0: Exp Down; 1: Ramp Down; 2: Tri; 3: Ramp Up; 4: Exp Up; 5: Ramp Down Loop; 6: Tri Loop; 7: Square Loop; 8: Ramp Up Loop; 9: Random; 10: Sample and Hold; 11: Wavetable 1/2 Loop
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Detune,,24,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Level,,25,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Position,,26,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Wavetable Slot,,27,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Speed,,28,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Animate Level,,29,,0,127,,,,,,,0-based,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Animate Position,,30,,0,127,,,,,,,centered,,
+Elektron,Tonverk,Machine: Wavefinder,Wavefinder Osc 2: Animate Shape,,31,,0,11,,,,,,,0-based,,0: Exp Down; 1: Ramp Down; 2: Tri; 3: Ramp Up; 4: Exp Up; 5: Ramp Down Loop; 6: Tri Loop; 7: Square Loop; 8: Ramp Up Loop; 9: Random; 10: Sample and Hold; 11: Wavetable 1/2 Loop
 Elektron,Tonverk,Audio Track: Filter,Filter: Parameter A,,70,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Audio Track: Filter,Filter: Parameter B,,71,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Audio Track: Filter,Filter: Parameter C,,72,,0,127,,,,,,,0-based,,
@@ -104,13 +146,14 @@ Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Attack,,,,,,,1,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Decay,,,,,,,1,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Sustain,,,,,,,1,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Release,,,,,,,1,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Frequecy,,,,,,,1,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Frequency,,,,,,,1,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Resonance,,,,,,,1,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Type,,,,,,,1,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Env Depth,,,,,,,1,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Env Depth,,,,,,,1,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Env Delay,,,,,,,1,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Base,,,,,,,1,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Width,,,,,,,1,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Frequency Spread,,,,,,,1,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Filter: Env Reset,,,,,,,1,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 1,Amp: Attack,,,,,,,1,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Amp: Hold,,,,,,,1,84,0,127,127,0-based,,127: Note
@@ -140,7 +183,7 @@ Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Attack,,,,,,,1,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Decay,,,,,,,1,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Sustain,,,,,,,1,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Release,,,,,,,1,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Reset,,,,,,,1,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Reset,,,,,,,1,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Delay,,,,,,,1,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 1,Subtrack Mod Env: Depth,,,,,,,1,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Source: Tune,,,,,,,2,16,0,16383,8191,centered,,
@@ -152,13 +195,14 @@ Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Attack,,,,,,,2,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Decay,,,,,,,2,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Sustain,,,,,,,2,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Release,,,,,,,2,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Frequecy,,,,,,,2,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Frequency,,,,,,,2,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Resonance,,,,,,,2,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Type,,,,,,,2,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Env Depth,,,,,,,2,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Env Depth,,,,,,,2,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Env Delay,,,,,,,2,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Base,,,,,,,2,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Width,,,,,,,2,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Frequency Spread,,,,,,,2,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Filter: Env Reset,,,,,,,2,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Attack,,,,,,,2,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Hold,,,,,,,2,84,0,127,127,0-based,,127: Note
@@ -166,7 +210,7 @@ Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Decay,,,,,,,2,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Sustain,,,,,,,2,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Release,,,,,,,2,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Overdrive,,,,,,,2,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Pan,,,,,,,2,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Pan,,,,,,,2,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Volume,,,,,,,2,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Mode,,,,,,,2,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 2,Amp: Env Reset,,,,,,,2,49,0,1,1,0-based,,0: Off; 1: On
@@ -188,7 +232,7 @@ Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Attack,,,,,,,2,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Decay,,,,,,,2,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Sustain,,,,,,,2,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Release,,,,,,,2,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Reset,,,,,,,2,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Reset,,,,,,,2,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Delay,,,,,,,2,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 2,Subtrack Mod Env: Depth,,,,,,,2,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Source: Tune,,,,,,,3,16,0,16383,8191,centered,,
@@ -200,13 +244,14 @@ Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Attack,,,,,,,3,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Decay,,,,,,,3,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Sustain,,,,,,,3,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Release,,,,,,,3,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Frequecy,,,,,,,3,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Frequency,,,,,,,3,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Resonance,,,,,,,3,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Type,,,,,,,3,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Env Depth,,,,,,,3,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Env Depth,,,,,,,3,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Env Delay,,,,,,,3,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Base,,,,,,,3,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Width,,,,,,,3,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Frequency Spread,,,,,,,3,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Filter: Env Reset,,,,,,,3,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Attack,,,,,,,3,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Hold,,,,,,,3,84,0,127,127,0-based,,127: Note
@@ -214,7 +259,7 @@ Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Decay,,,,,,,3,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Sustain,,,,,,,3,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Release,,,,,,,3,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Overdrive,,,,,,,3,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Pan,,,,,,,3,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Pan,,,,,,,3,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Volume,,,,,,,3,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Mode,,,,,,,3,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 3,Amp: Env Reset,,,,,,,3,49,0,1,1,0-based,,0: Off; 1: On
@@ -236,7 +281,7 @@ Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Attack,,,,,,,3,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Decay,,,,,,,3,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Sustain,,,,,,,3,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Release,,,,,,,3,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Reset,,,,,,,3,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Reset,,,,,,,3,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Delay,,,,,,,3,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 3,Subtrack Mod Env: Depth,,,,,,,3,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Source: Tune,,,,,,,4,16,0,16383,8191,centered,,
@@ -248,13 +293,14 @@ Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Attack,,,,,,,4,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Decay,,,,,,,4,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Sustain,,,,,,,4,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Release,,,,,,,4,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Frequecy,,,,,,,4,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Frequency,,,,,,,4,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Resonance,,,,,,,4,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Type,,,,,,,4,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Env Depth,,,,,,,4,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Env Depth,,,,,,,4,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Env Delay,,,,,,,4,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Base,,,,,,,4,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Width,,,,,,,4,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Frequency Spread,,,,,,,4,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Filter: Env Reset,,,,,,,4,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Attack,,,,,,,4,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Hold,,,,,,,4,84,0,127,127,0-based,,127: Note
@@ -262,7 +308,7 @@ Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Decay,,,,,,,4,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Sustain,,,,,,,4,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Release,,,,,,,4,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Overdrive,,,,,,,4,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Pan,,,,,,,4,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Pan,,,,,,,4,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Volume,,,,,,,4,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Mode,,,,,,,4,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 4,Amp: Env Reset,,,,,,,4,49,0,1,1,0-based,,0: Off; 1: On
@@ -284,7 +330,7 @@ Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Attack,,,,,,,4,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Decay,,,,,,,4,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Sustain,,,,,,,4,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Release,,,,,,,4,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Reset,,,,,,,4,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Reset,,,,,,,4,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Delay,,,,,,,4,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 4,Subtrack Mod Env: Depth,,,,,,,4,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Source: Tune,,,,,,,5,16,0,16383,8191,centered,,
@@ -296,13 +342,14 @@ Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Attack,,,,,,,5,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Decay,,,,,,,5,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Sustain,,,,,,,5,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Release,,,,,,,5,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Frequecy,,,,,,,5,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Frequency,,,,,,,5,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Resonance,,,,,,,5,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Type,,,,,,,5,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Env Depth,,,,,,,5,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Env Depth,,,,,,,5,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Env Delay,,,,,,,5,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Base,,,,,,,5,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Width,,,,,,,5,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Frequency Spread,,,,,,,5,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Filter: Env Reset,,,,,,,5,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Attack,,,,,,,5,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Hold,,,,,,,5,84,0,127,127,0-based,,127: Note
@@ -310,7 +357,7 @@ Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Decay,,,,,,,5,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Sustain,,,,,,,5,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Release,,,,,,,5,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Overdrive,,,,,,,5,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Pan,,,,,,,5,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Pan,,,,,,,5,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Volume,,,,,,,5,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Mode,,,,,,,5,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 5,Amp: Env Reset,,,,,,,5,49,0,1,1,0-based,,0: Off; 1: On
@@ -332,7 +379,7 @@ Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Attack,,,,,,,5,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Decay,,,,,,,5,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Sustain,,,,,,,5,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Release,,,,,,,5,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Reset,,,,,,,5,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Reset,,,,,,,5,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Delay,,,,,,,5,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 5,Subtrack Mod Env: Depth,,,,,,,5,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Source: Tune,,,,,,,6,16,0,16383,8191,centered,,
@@ -344,13 +391,14 @@ Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Attack,,,,,,,6,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Decay,,,,,,,6,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Sustain,,,,,,,6,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Release,,,,,,,6,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Frequecy,,,,,,,6,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Frequency,,,,,,,6,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Resonance,,,,,,,6,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Type,,,,,,,6,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Env Depth,,,,,,,6,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Env Depth,,,,,,,6,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Env Delay,,,,,,,6,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Base,,,,,,,6,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Width,,,,,,,6,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Frequency Spread,,,,,,,6,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Filter: Env Reset,,,,,,,6,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Attack,,,,,,,6,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Hold,,,,,,,6,84,0,127,127,0-based,,127: Note
@@ -358,7 +406,7 @@ Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Decay,,,,,,,6,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Sustain,,,,,,,6,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Release,,,,,,,6,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Overdrive,,,,,,,6,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Pan,,,,,,,6,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Pan,,,,,,,6,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Volume,,,,,,,6,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Mode,,,,,,,6,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 6,Amp: Env Reset,,,,,,,6,49,0,1,1,0-based,,0: Off; 1: On
@@ -380,7 +428,7 @@ Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Attack,,,,,,,6,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Decay,,,,,,,6,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Sustain,,,,,,,6,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Release,,,,,,,6,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Reset,,,,,,,6,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Reset,,,,,,,6,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Delay,,,,,,,6,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 6,Subtrack Mod Env: Depth,,,,,,,6,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Source: Tune,,,,,,,7,16,0,16383,8191,centered,,
@@ -392,13 +440,14 @@ Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Attack,,,,,,,7,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Decay,,,,,,,7,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Sustain,,,,,,,7,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Release,,,,,,,7,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Frequecy,,,,,,,7,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Frequency,,,,,,,7,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Resonance,,,,,,,7,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Type,,,,,,,7,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Env Depth,,,,,,,7,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Env Depth,,,,,,,7,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Env Delay,,,,,,,7,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Base,,,,,,,7,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Width,,,,,,,7,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Frequency Spread,,,,,,,7,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Filter: Env Reset,,,,,,,7,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Attack,,,,,,,7,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Hold,,,,,,,7,84,0,127,127,0-based,,127: Note
@@ -406,7 +455,7 @@ Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Decay,,,,,,,7,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Sustain,,,,,,,7,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Release,,,,,,,7,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Overdrive,,,,,,,7,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Pan,,,,,,,7,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Pan,,,,,,,7,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Volume,,,,,,,7,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Mode,,,,,,,7,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 7,Amp: Env Reset,,,,,,,7,49,0,1,1,0-based,,0: Off; 1: On
@@ -428,7 +477,7 @@ Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Attack,,,,,,,7,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Decay,,,,,,,7,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Sustain,,,,,,,7,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Release,,,,,,,7,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Reset,,,,,,,7,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Reset,,,,,,,7,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Delay,,,,,,,7,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 7,Subtrack Mod Env: Depth,,,,,,,7,125,0,16383,8191,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Source: Tune,,,,,,,8,16,0,16383,8191,centered,,
@@ -440,13 +489,14 @@ Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Attack,,,,,,,8,70,0,127,,0-base
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Decay,,,,,,,8,71,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Sustain,,,,,,,8,72,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Release,,,,,,,8,73,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Frequecy,,,,,,,8,74,0,16383,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Frequency,,,,,,,8,74,0,16383,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Resonance,,,,,,,8,75,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Type,,,,,,,8,76,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Env Depth,,,,,,,8,77,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Env Depth,,,,,,,8,77,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Env Delay,,,,,,,8,46,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Base,,,,,,,8,78,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Width,,,,,,,8,79,0,127,,0-based,,
+Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Frequency Spread,,,,,,,8,80,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Filter: Env Reset,,,,,,,8,45,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Attack,,,,,,,8,83,0,127,0,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Hold,,,,,,,8,84,0,127,127,0-based,,127: Note
@@ -454,7 +504,7 @@ Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Decay,,,,,,,8,85,0,127,64,0-based,
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Sustain,,,,,,,8,86,0,127,127,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Release,,,,,,,8,87,0,127,32,0-based,,127: Infinite
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Overdrive,,,,,,,8,88,0,127,0,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Pan,,,,,,,8,10,0,128,64,centered,,
+Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Pan,,,,,,,8,10,0,127,64,centered,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Volume,,,,,,,8,89,0,127,110,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Mode,,,,,,,8,48,0,1,0,0-based,,0: AHD; 1: ADSR
 Elektron,Tonverk,Audio Track: Subtrack 8,Amp: Env Reset,,,,,,,8,49,0,1,1,0-based,,0: Off; 1: On
@@ -476,9 +526,11 @@ Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Attack,,,,,,,8,118,0,
 Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Decay,,,,,,,8,119,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Sustain,,,,,,,8,120,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Release,,,,,,,8,121,0,127,,0-based,,
-Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Reset,,,,,,,8,122,0,1,,0-based,,0: On; 1: Off
+Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Reset,,,,,,,8,122,0,1,,0-based,,0: Off; 1: On
 Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Delay,,,,,,,8,123,0,127,,0-based,,
 Elektron,Tonverk,Audio Track: Subtrack 8,Subtrack Mod Env: Depth,,,,,,,8,125,0,16383,8191,centered,,
+Elektron,Tonverk,Bus Track,Track: Global Mute,,94,,0,1,0,,,,,,0-based,,0: Unmuted; 1: Muted
+Elektron,Tonverk,Bus Track,Track: Level,,95,,0,127,100,,,,,,0-based,,
 Elektron,Tonverk,Bus Track: Trig,Trig: Note,,3,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Bus Track: Trig,Trig: Velocity,,4,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Bus Track: Trig,Trig: Note Length,,5,,0,127,,,,,,,0-based,,
@@ -508,6 +560,8 @@ Elektron,Tonverk,Bus Track: Mod,LFO 1: Depth,,113,,0,127,63,,,,,,centered,,
 Elektron,Tonverk,Bus Track: Mod,LFO 2: Speed,,114,,0,127,95,,,,,,centered,,
 Elektron,Tonverk,Bus Track: Mod,LFO 2: Multiplier,,115,,0,23,1,,,,,,0-based,,0: BPM 1; 1: BPM 2; 2: BPM 4; 3: BPM 8; 4: BPM 16; 5: BPM 32; 6: BPM 64; 7: BPM 128; 8: BPM 256; 9: BPM 512; 10: BPM 1K; 11: BPM 2K; 12: 1; 13: 2; 14: 4; 15: 8; 16: 16; 17: 32; 18: 64; 19: 128; 20: 256; 21: 512; 22: 1K; 23: 2K
 Elektron,Tonverk,Bus Track: Mod,LFO 2: Depth,,116,,0,127,63,,,,,,centered,,
+Elektron,Tonverk,Send Track,Track: Global Mute,,94,,0,1,0,,,,,,0-based,,0: Unmuted; 1: Muted
+Elektron,Tonverk,Send Track,Track: Level,,95,,0,127,100,,,,,,0-based,,
 Elektron,Tonverk,Send Track: Trig,Trig: Note,,3,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Send Track: Trig,Trig: Velocity,,4,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Send Track: Trig,Trig: Note Length,,5,,0,127,,,,,,,0-based,,
@@ -526,6 +580,8 @@ Elektron,Tonverk,Send Track: Mod,LFO 1: Depth,,113,,0,127,63,,,,,,centered,,
 Elektron,Tonverk,Send Track: Mod,LFO 2: Speed,,114,,0,127,95,,,,,,centered,,
 Elektron,Tonverk,Send Track: Mod,LFO 2: Multiplier,,115,,0,23,1,,,,,,0-based,,0: BPM 1; 1: BPM 2; 2: BPM 4; 3: BPM 8; 4: BPM 16; 5: BPM 32; 6: BPM 64; 7: BPM 128; 8: BPM 256; 9: BPM 512; 10: BPM 1K; 11: BPM 2K; 12: 1; 13: 2; 14: 4; 15: 8; 16: 16; 17: 32; 18: 64; 19: 128; 20: 256; 21: 512; 22: 1K; 23: 2K
 Elektron,Tonverk,Send Track: Mod,LFO 2: Depth,,116,,0,127,63,,,,,,centered,,
+Elektron,Tonverk,Mix Track,Track: Global Mute,,94,,0,1,0,,,,,,0-based,,0: Unmuted; 1: Muted
+Elektron,Tonverk,Mix Track,Track: Level,,95,,0,127,100,,,,,,0-based,,
 Elektron,Tonverk,Mix Track: Trig,Trig: Note,,3,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Mix Track: Trig,Trig: Velocity,,4,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,Mix Track: Trig,Trig: Note Length,,5,,0,127,,,,,,,0-based,,
@@ -614,7 +670,7 @@ Elektron,Tonverk,FX: Daisy Delay,FX 1: Width,,51,,0,127,63,,,,,,centered,,
 Elektron,Tonverk,FX: Daisy Delay,FX 1: Modulation,,52,,0,127,32,,,,,,0-based,,
 Elektron,Tonverk,FX: Daisy Delay,FX 1: Skew,,53,,0,127,63,,,,,,centered,,
 Elektron,Tonverk,FX: Daisy Delay,FX 1: Filter,,54,,0,127,63,,,,,,centered,,
-Elektron,Tonverk,FX: Daisy Delay,FX 1: Mix,,54,,0,127,63,,,,,,centered,,
+Elektron,Tonverk,FX: Daisy Delay,FX 1: Mix,,55,,0,127,63,,,,,,centered,,
 Elektron,Tonverk,FX: Daisy Delay,FX 2: Drive,,56,,0,127,32,,,,,,0-based,,
 Elektron,Tonverk,FX: Daisy Delay,FX 2: Delay Time Division,,57,,0,127,,,,,,,0-based,,
 Elektron,Tonverk,FX: Daisy Delay,FX 2: Feedback,,58,,0,127,96,,,,,,0-based,,
@@ -664,7 +720,7 @@ Elektron,Tonverk,FX: Filter Folder,FX 1: Resonance,,53,,0,127,0,,,,,,0-based,,
 Elektron,Tonverk,FX: Filter Folder,FX 1: Type,,54,,0,7,0,,,,,,0-based,,0: LP4; 1: LP2; 2: BP2; 3: HP2; 4: LP.N; 5: NCH1; 6: NCH2; 7: OFF
 Elektron,Tonverk,FX: Filter Folder,FX 1: Post Distortion,,55,,0,127,0,,,,,,0-based,,
 Elektron,Tonverk,FX: Filter Folder,FX 2: In,,56,,0,127,63,,,,,,centered,,
-Elektron,Tonverk,FX: Filter Folder,FX 2: Hight Pass,,57,,0,127,0,,,,,,0-based,,
+Elektron,Tonverk,FX: Filter Folder,FX 2: High Pass,,57,,0,127,0,,,,,,0-based,,
 Elektron,Tonverk,FX: Filter Folder,FX 2: Folder,,58,,0,127,0,,,,,,0-based,,
 Elektron,Tonverk,FX: Filter Folder,FX 2: Out,,59,,0,127,63,,,,,,centered,,
 Elektron,Tonverk,FX: Filter Folder,FX 2: Frequency,,60,,0,127,127,,,,,,0-based,,


### PR DESCRIPTION
Fixes typos (Frequecy, Hight Pass), inverted Mod Env Reset values, Amp Pan and Filter Env Depth max values, and Daisy Delay FX 1 Mix CC. Adds missing Filter Frequency Spread for all subtracks, Global Mute and Track Level for Bus/Send/Mix tracks.
Adds machine-specific params for Single Player, Multi Player, Grainer, and the new Wavefinder wavetable machine.

FW v1.30