### PR TITLE
Fixing Digitakt II definition against manual

### DIFF
--- a/Elektron/Digitakt II.csv
+++ b/Elektron/Digitakt II.csv
@@ -16,7 +16,7 @@ Elektron,Digitakt II,Source: Generic,Source: Parameter E,,20,,0,127,,1,4,0,15360
 Elektron,Digitakt II,Source: Generic,Source: Parameter F,,21,,0,127,,1,5,0,15360,,0-based,,
 Elektron,Digitakt II,Source: Generic,Source: Parameter G,,22,,0,127,,1,6,0,15360,,0-based,,
 Elektron,Digitakt II,Source: Generic,Source: Sample Level,,23,,0,127,,1,7,0,127,,0-based,,
-Elektron,Digitakt II,Source: Oneshot,Oneshot: Tune,,16,,0,127,63,1,0,512,15872,8192 ,centered,,
+Elektron,Digitakt II,Source: Oneshot,Oneshot: Tune,,16,,0,127,63,1,0,512,15872,8192,centered,,
 Elektron,Digitakt II,Source: Oneshot,Oneshot: Play Mode,,17,,0,3,3,1,1,0,3,3,0-based,,0: Reverse; 1: Reverse Loop; 2: Forward Loop; 3: Forward
 Elektron,Digitakt II,Source: Oneshot,Oneshot: Sample Bank Select,,24,,0,127,,1,9,0,16383,,0-based,,
 Elektron,Digitakt II,Source: Oneshot,Oneshot: Sample Slot Select,,19,,0,127,,1,8,0,16383,,0-based,,
@@ -160,7 +160,7 @@ Elektron,Digitakt II,Filter: Equalizer,Equalizer: Base,,26,,0,127,0,1,51,0,127,0
 Elektron,Digitakt II,Filter: Equalizer,Equalizer: Width,,27,,0,127,127,1,52,0,127,127,0-based,,
 Elektron,Digitakt II,Filter: Equalizer,Equalizer: BW Routing,,27,,0,1,0,1,15,0,1,0,0-based,,0: Pre Filter; 1: Post Filter
 Elektron,Digitakt II,Filter: Equalizer,Equalizer: Env.Reset,,111,,0,1,0,1,68,0,1,0,0-based,,0: Off; 1: On
-Elektron,Digitakt II,Amp,Amp: Attack Time,0,79,,0,127,0,1,30,0,127,0,0-based,,
+Elektron,Digitakt II,Amp,Amp: Attack Time,,79,,0,127,0,1,30,0,127,0,0-based,,
 Elektron,Digitakt II,Amp,Amp: Hold Time,,80,,0,127,127,1,31,0,127,127,0-based,,127: Note
 Elektron,Digitakt II,Amp,Amp: Decay Time,,81,,0,127,64,1,32,0,127,64,0-based,,127: Infinite
 Elektron,Digitakt II,Amp,Amp: Sustain Level,,82,,0,127,127,1,33,0,127,127,0-based,,
@@ -199,7 +199,7 @@ Elektron,Digitakt II,FX,Chorus: Width,,71,,0,127,127,2,44,0,127,127,0-based,,
 Elektron,Digitakt II,FX,Chorus: Delay Send,,12,,0,127,0,2,45,0,127,0,0-based,,
 Elektron,Digitakt II,FX,Chorus: Reverb Send,,13,,0,127,0,2,46,0,127,0,0-based,,
 Elektron,Digitakt II,FX,Chorus: Mix Volume,,14,,0,127,100,2,47,0,127,100,0-based,,
-Elektron,Digitakt II,Mod,LFO 1: Speed,,102,58,0,16383,6144,1,45,0,16383,6144,centered,,
+Elektron,Digitakt II,Mod,LFO 1: Speed,,102,58,0,16383,6144,1,42,0,16383,6144,centered,,
 Elektron,Digitakt II,Mod,LFO 1: Multiplier,,103,,0,23,1,1,43,0,23,1,0-based,,0: BPM 1; 1: BPM 2; 2: BPM 4; 3: BPM 8; 4: BPM 16; 5: BPM 32; 6: BPM 64; 7: BPM 128; 8: BPM 256; 9: BPM 512; 10: BPM 1K; 11: BPM 2K; 12: 1; 13: 2; 14: 4; 15: 8; 16: 16; 17: 32; 18: 64; 19: 128; 20: 256; 21: 512; 22: 1K; 23: 2K
 Elektron,Digitakt II,Mod,LFO 1: Fade In/Out,,104,,0,127,63,1,44,0,127,63,centered,,
 Elektron,Digitakt II,Mod,LFO 1: Destination,,105,,0,127,0,1,45,0,127,0,0-based,,
@@ -239,7 +239,7 @@ Elektron,Digitakt II,Mixer,External Mixer: Input L Delay Send,,78,,0,127,0,2,36,
 Elektron,Digitakt II,Mixer,External Mixer: Input L Reverb Send,,80,,0,127,0,2,38,0,127,0,0-based,,
 Elektron,Digitakt II,Mixer,External Mixer: Input L Chorus Send,,76,,0,127,0,2,34,0,127,0,0-based,,
 Elektron,Digitakt II,Mixer,External Mixer: Input R Level,,73,,0,127,0,2,31,0,127,0,0-based,,
-Elektron,Digitakt II,Mixer,External Mixer: Input R Pan,,75,,0,127,63,2,33,0,127,53,centered,,
+Elektron,Digitakt II,Mixer,External Mixer: Input R Pan,,75,,0,127,63,2,33,0,127,63,centered,,
 Elektron,Digitakt II,Mixer,External Mixer: Input R Delay Send,,79,,0,127,0,2,37,0,127,0,0-based,,
 Elektron,Digitakt II,Mixer,External Mixer: Input R Reverb Send,,81,,0,127,0,2,39,0,127,0,0-based,,
 Elektron,Digitakt II,Mixer,External Mixer: Input R Chorus Send,,77,,0,127,0,2,35,0,127,0,0-based,,


### PR DESCRIPTION
Removes spurious 0 in Amp Attack Time description field. Removes trailing space in Oneshot Tune NRPN default. Corrects LFO 1 Speed NRPN LSB from 45 to 42.
Fixes External Mixer Input R Pan NRPN default from 53 to 63.