### PR TITLE
Fixing Analog Four MKII definition against OS 1.51C manual

### DIFF
--- a/Elektron/Analog Four MKII.csv
+++ b/Elektron/Analog Four MKII.csv
@@ -9,8 +9,8 @@ Elektron,Analog Four MKII,Performance,Performance: Parameter G,,65,,0,127,,0,6,0
 Elektron,Analog Four MKII,Performance,Performance: Parameter H,,66,,0,127,,0,7,0,127,,0-based,,
 Elektron,Analog Four MKII,Performance,Performance: Parameter I,,67,,0,127,,0,8,0,127,,0-based,,
 Elektron,Analog Four MKII,Performance,Performance: Parameter J,,68,,0,127,,0,9,0,127,,0-based,,
-Elektron,Analog Four MKII,Modulation,Modulation: Modwheel,,1,,0,127,,,,,,,0-based,,
-Elektron,Analog Four MKII,Modulation,Modulation: Breath,,2,,0,127,,,,,,,0-based,,
+Elektron,Analog Four MKII,Modulation,Modulation: Modwheel,,1,33,0,127,,,,,,,0-based,,
+Elektron,Analog Four MKII,Modulation,Modulation: Breath,,2,34,0,127,,,,,,,0-based,,
 Elektron,Analog Four MKII,Track,Track: Mute,,94,,0,1,,1,101,0,1,,0-based,,0: Off; 1: On
 Elektron,Analog Four MKII,Track,Track: Level,,95,,0,127,,1,100,0,127,,0-based,,
 Elektron,Analog Four MKII,Synth: OSC1,OSC1: Pitch,,16,48,0,16383,,1,0,0,16383,,centered,,
@@ -26,12 +26,12 @@ Elektron,Analog Four MKII,Synth: OSC1,OSC1: AM,,,,,,,1,30,0,1,,0-based,,0: Off; 
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: Pitch,,17,49,0,16383,,1,20,0,16383,,centered,,
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: Detune,,,,,,,1,22,0,127,,0-based,,
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: Keytracking,,,,,,,1,23,0,1,,0-based,,0: Off; 1: On
-Elektron,Analog Four MKII,Synth: OSC2,OSC2: Level,,78,,0,127,,1,2,0,127,,0-based,,
+Elektron,Analog Four MKII,Synth: OSC2,OSC2: Level,,78,,0,127,,1,24,0,127,,0-based,,
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: Waveform,,79,,0,7,,1,25,0,7,,0-based,,0: Sawtooth; 1: Transistor Pulse; 2: Pulse; 3: Triangle; 4: In Left; 5: In Right; 6: Neighbor; 7: Off
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: Sub Oscillator,,80,,0,4,,1,26,0,4,,0-based,,0: Off; 1: 1 Octave; 2: 2 Octave; 3: 2 Pulse; 4: 5th
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: Pulsewidth,,81,,0,127,,1,27,0,127,,centered,,
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: PWM Speed,,82,,0,127,,1,,0,127,,0-based,,
-Elektron,Analog Four MKII,Synth: OSC2,OSC2: PWM Depth,,82,,0,127,,1,29,0,127,,0-based,,
+Elektron,Analog Four MKII,Synth: OSC2,OSC2: PWM Depth,,83,,0,127,,1,29,0,127,,0-based,,
 Elektron,Analog Four MKII,Synth: OSC2,OSC2: AM,,,,,,,1,35,0,1,,0-based,,0: Off; 1: On
 Elektron,Analog Four MKII,Synth: OSC,OSC: Sync Mode,,,,,,,1,31,0,3,,0-based,,0: Off; 1: Osc1->Osc2; 2: Osc2->Osc1; 3: Metal Sync
 Elektron,Analog Four MKII,Synth: OSC,OSC: Sync Amount,,84,,0,127,,1,32,0,127,,0-based,,
@@ -78,7 +78,7 @@ Elektron,Analog Four MKII,Envelopes,Filter Env: Depth B,,21,53,0,127,,1,69,0,127
 Elektron,Analog Four MKII,Envelopes,AUX Env: Attack,,112,,0,127,,1,70,0,127,,0-based,,
 Elektron,Analog Four MKII,Envelopes,AUX Env: Decay,,113,,0,127,,1,71,0,127,,0-based,,
 Elektron,Analog Four MKII,Envelopes,AUX Env: Sustain,,114,,0,127,,1,72,0,127,,0-based,,
-Elektron,Analog Four MKII,Envelopes,AUX Env: Release,,115,,0,127,,1,7,0,127,,0-based,,
+Elektron,Analog Four MKII,Envelopes,AUX Env: Release,,115,,0,127,,1,73,0,127,,0-based,,
 Elektron,Analog Four MKII,Envelopes,AUX Env: Shape,,,,,,,1,74,0,11,,0-based,,0: Linear ADR; 1: Linear ADR (R); 2: Standard; 3: Standard (R); 4: E.A / L.DR; 5: E.A / L.DR (R); 6: Exp. ADR; 7: Exp. ADR (R); 8: Full ADR; 9: Full ADR (R); 10: F.A / E.DR; 11: F.A / E.DR (R)
 Elektron,Analog Four MKII,Envelopes,AUX Env: Gate Length,,,,,,,1,75,0,127,,0-based,,
 Elektron,Analog Four MKII,Envelopes,AUX Env: Destination A,,,,,,,1,76,0,127,,0-based,,96: META:None; 18: OSC1:Pitch Mod; 97: OSC1:Freq Mod; 2: OSC1:Linear Detune; 4: OSC1:Keytrack; 6: OSC1:Level; 8: OSC1:Waveform; 10: OSC1:Sub Oscilator; 12: OSC1:Pulsewidth; 14: OSC1:PWM Speed; 16: OSC1:PWM Depth; 24: OSC1:Osc1 AM; 19: OSC2:Pitch Mod; 98: OSC2:Freq Mod; 3: OSC2:Linear Detune; 5: OSC2:Keytrack; 7: OSC2:Level; 9: OSC2:Waveform; 11: OSC2:Sub Oscilator; 13: OSC2:Pulsewidth; 15: OSC2:PWM Speed; 17: OSC2:PWM Depth; 25: OSC2:Osc2 AM; 20: OSCX:Pitch Mod; 99: OSCX:Freq Mod; 26: OSCX:Sync Mode; 27: OSCX:Sync Amount; 28: OSCX:Bend Depth; 29: OSCX:Note Slide Time; 31: OSCX:Vibrato Fade; 32: OSCX:Vibrato Speed; 33: OSCX:Vibrato Depth; 21: NOISE:Noise S&H; 100: NOISE:Noise Color; 22: NOISE:Noise Fade; 23: NOISE:Noise Level; 34: FILT:F1 Frequency; 35: FILT:F1 Resonance; 38: FILT:F1 EnfF Depth; 36: FILT:F1 Overdrive; 39: FILT:F2 Frequency; 40: FILT:F2 Resonance; 43: FILT:F2 EnvF Depth; 44: FILT:F1+F2 Freq.; 53: AMP:EnvA Attack; 56: AMP:EnvA Decay; 59: AMP:EnvA Sustain; 62: AMP:EnvA Release; 65: AMP:EnvA Shape; 45: AMP:Chorus Send; 46: AMP:Delay Send; 47: AMP:Reverb Send; 48: AMP:Pan; 49: AMP:Volume; 50: AMP:Accent Level; 51: ENVF:Attack; 54: ENVF:Decay; 57: ENVF:Sustain; 60: ENVF:Release; 63: ENVF:Shape; 72: ENVF:Depth A; 73: ENVF:Depth B; 76: LFO1:Speed; 78: LFO1:Multiplier; 80: LFO1:Fade In/Out; 82: LFO1:Start Phase; 92: LFO1:Depth A; 93: LFO1:Depth B; 0-127: META:None


### PR DESCRIPTION
Corrects OSC2 Level NRPN LSB from 2 to 24.
Corrects AUX Env Release NRPN LSB from 7 to 73.
Fixes OSC2 PWM Depth CC from 82 to 83 (was conflicting with PWM Speed). Adds missing CC LSBs for Modwheel (33) and Breath (34).