### PR TITLE
Add Deco Support

### DIFF
--- a/Strymon/Deco.csv
+++ b/Strymon/Deco.csv
@@ -1,0 +1,23 @@
+manufacturer,device,section,parameter_name,parameter_description,cc_msb,cc_lsb,cc_min_value,cc_max_value,cc_default_value,nrpn_msb,nrpn_lsb,nrpn_min_value,nrpn_max_value,nrpn_default_value,orientation,notes,usage
+Strymon,Deco,Control,Bank Select,"Selects between preset banks 0, 1 and 2",0,,0,2,0,,,,,,0-based,,0: Bank 1; 1: Bank 2; 2: Bank 3
+Strymon,Deco,Control,Tape Saturation On/Off,Tape Saturation Side On/Off Toggle,10,,0,127,0,,,,,,0-based,,0: Off; 1-127; On
+Strymon,Deco,Primary,Voice,Tape saturation voice 1: Tape; 2: Cassette,11,,1,2,1,,,,,,0-based,,1: Tape; 2: Cassette
+Strymon,Deco,Primary,Saturation,Tape saturation level,12,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Primary,Volume,Tape saturation volume,13,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Primary,Tone,Tape saturation tone,14,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Hidden,Low Trim,Tape saturation low trim,15,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Control,Doubletracker On/Off,Doubletracker side On/Off Toggle,16,,0,127,0,,,,,,0-based,,0: Off; 1-127; On
+Strymon,Deco,Primary,Type,Doubletracker type 1: Sum; 2: Invert; 3: Bounce,17,,1,3,1,,,,,,0-based,,1: Sum; 2: Invert; 3: Bounce
+Strymon,Deco,Primary,Lag Time,Doubletracker offset between reference and lag decks,18,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Primary,Wobble,Doubletrakcer adds random modulation to lag deck,19,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Primary,Blend,"Doubletracker blend between reference and lag decks, larger value is more lag deck, middle is even blend",20,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Hidden,Doubletracker Boost/Cut,-3 dB to +3dB on doubletracker for precise level matching,21,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Hidden,Auto-Flange Time,Sweep time for auto flange effect,22,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Hidden,Wide Stereo Mode On/Off,Generate wide stereo image sending reference deck to left out and lag deck to right out,23,,0,127,0,,,,,,0-based,,
+Strymon,Deco,Control,MIDI Clock Tempo Mult/Div,"When synced to MIDI clock, mult/div of incoming tempo:  x2/3, x1, x2, x3, x4, x6, and x8",25,,0,6,1,,,,,,0-based,,0: x2/3; 1: x1; 2: x2; 3: x3; 4: x4; 5: x6; 6: x8 
+Strymon,Deco,Control,Bypass/On A and B,Bypass pedal,33,,0,127,0,,,,,,0-based,,0: Bypass; 1-127; On
+Strymon,Deco,Control,MIDI Expression On/Off,Enable/disable MIDI Expression via CC 100 (Expression Pedal),60,,0,127,0,,,,,,0-based,,0: Off; 1-127; On
+Strymon,Deco,Control,MIDI Clock On/Off,Enable/disable MIDI Clock ,63,,0,127,0,,,,,,0-based,,0: Off; 1-127; On
+Strymon,Deco,Control,Remote Tap,Set lag time via tap tempo,93,,0,127,0,,,,,,0-based,Any Value ,
+Strymon,Deco,Control,Auto-Flange,Auto-Flange On/Off,97,,0,127,0,,,,,,0-based,,0: Off; 1-127; On
+Strymon,Deco,Expression,Expression Pedal,"Sends expression pedal values, the parameters affected must be configured per the manual",100,,0,127,0,,,,,,0-based,,0: Heel; 127; Toe


### PR DESCRIPTION
Added support for the Strymon Deco v2 Pedal, my favorite pedal.  

All values were added directly from the latest user manual, for firmware version 1.33:    https://www.strymon.net/manuals/Deco_v2_UserManual_RevD.pdf 

Descriptions were edited for brevity from the direct text in the manual.

No AI used.